### PR TITLE
chore: update pnpm/action-setup from v5 to v6

### DIFF
--- a/.github/workflows/build-output-check.yml
+++ b/.github/workflows/build-output-check.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288 # v5
+        uses: pnpm/action-setup@71c92474e7e4f5bca283fb17ef80fba9cdb2b4b1 # v6
         with:
           version: 10
 

--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288 # v5
+        uses: pnpm/action-setup@71c92474e7e4f5bca283fb17ef80fba9cdb2b4b1 # v6
         with:
           version: 10
 


### PR DESCRIPTION
## Summary

- `pnpm/action-setup` を v5 → v6 に更新
- コミットハッシュを `a8198c4b` → `71c92474` に変更
- Dependabot PR #59 はハッシュが v5 のままだったため、正しい v6 のハッシュで手動更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)